### PR TITLE
Fix a mis-implementation in ALPSO.

### DIFF
--- a/liso/optimizers/alpso.py
+++ b/liso/optimizers/alpso.py
@@ -255,10 +255,14 @@ def alpso(x0,
                 v_k[i, x_k[i, :] == 1] = 0
                 v_k[i, x_k[i, :] == 0] = 0
 
-                # update Lagrangian function values
+            # update Lagrangian function values
+            # TODO: parallelize this loop
+            for i in range(swarm_size):
                 f[i], g[i, :] = f_obj_con(x_k[i, :])
                 nfeval += 1
 
+            # update Lagrangian, particle best and global best
+            for i in range(swarm_size):
                 L[i] = f[i]
                 for j in range(n_cons):
                     # Equality Constraints
@@ -270,18 +274,16 @@ def alpso(x0,
 
                     L[i] += lambda_[j] * theta + rp[j] * theta ** 2
 
-                # update particle best
                 if L[i] < pbest_L[i]:
                     pbest_L[i] = L[i]
-                    pbest_x[i, :] = np.copy(x_k[i, :])
+                    pbest_x[i, :] = x_k[i, :]
 
-                # update global best
                 if L[i] < gbest_L:
                     gbest_i = i
-                    gbest_x = np.copy(x_k[i, :])
+                    gbest_x[:] = x_k[i, :]
                     gbest_L = L[i]
                     gbest_f = f[i]
-                    gbest_g = np.copy(g[i, :])
+                    gbest_g[:] = g[i, :]
 
             # update divergence
             divergence = np.sqrt(np.sum(np.var(x_k, axis=0)))
@@ -473,15 +475,15 @@ def alpso(x0,
 
             # reset swarm's best for the next inner loop
             gbest_i = L.argmin()
-            gbest_x = np.copy(x_k[gbest_i, :])
+            gbest_x[:] = x_k[gbest_i, :]
             gbest_L = L[gbest_i]
             gbest_f = f[gbest_i]
-            gbest_g = np.copy(g[gbest_i, :])
+            gbest_g[:] = g[gbest_i, :]
 
             # reset particles' memory (i.e. particle's best for the next
             # inner loop)
-            pbest_x = np.copy(x_k)
-            pbest_L = np.copy(L)
+            pbest_x[:, :] = x_k[:, :]
+            pbest_L[:] = L[:]
 
     # save the optimization history to an hdf5 file
     # with h5py.File('/tmp/optimization_history.hdf5', 'w') as fp:

--- a/liso/optimizers/pyALPSO.py
+++ b/liso/optimizers/pyALPSO.py
@@ -63,7 +63,7 @@ class ALPSO(Optimizer):
         self.itol = 1e-3
         self.rtol = 1e-2
         self.atol = 1e-4
-        self.dtol = 5e-2
+        self.dtol = 1e-1
 
         self.c1 = 1.5
         self.c2 = 1.5


### PR DESCRIPTION
The global Langrangian was updated during updating each particles
in a swarm, which means they could use different gbest_L if gbest_L
was updated in the early phase of the for loop. Now, the updation
of gbest_L is in a different loop.

Increase the default dtol from 0.05 to 0.1